### PR TITLE
Module doubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Double
-Double is a simple library to help build injectable dependencies for your tests.
+Double builds on-the-fly injectable dependencies for your tests.
 It does NOT override behavior of existing modules or functions.
 
 ## Installation
@@ -16,60 +16,99 @@ The package can be installed as:
 
 ## Usage
 
-The first step is to make sure the function you want to test will have it's dependencies injected.
-This library requires usage of a map or struct:
+### Module Doubles
 
-### With Map
-```elixir
-defmodule Example do
-  @inject %{
-    puts: &IO.puts/1,
-    some_service: &SomeService.process/3,
-  }
-
-  def process(inject \\ @inject) do
-    inject.puts.("It works without mocking libraries")
-    inject.some_service.(1, 2, 3)
-  end
-end
-```
-
-### With Struct
-
-Using a struct has the benefit of throwing an error when trying to allow a non-existent key, and
-you may also re-use your struct if you share similar dependencies throughout your app.
+Module doubles are probably the most straightforward way to use Double.
+You're just creating fake versions of an existing module.
+You can use this module like any other module that you call functions on.
 
 ```elixir
 defmodule Example do
-  defmodule Inject do
-    defstruct puts: &IO.puts/1, some_service: &SomeService.process/3
-  end
-
-  def process(inject \\ %Inject{}) do
-    inject.puts.("It works without mocking libraries")
-    inject.some_service.(1, 2, 3)
+  def process(io \\ IO) do
+    io.puts("It works without mocking libraries")
   end
 end
 
-```
-
-### Setting up your doubles
-
-```elixir
 defmodule ExampleTest do
   use ExUnit.Case
   import Double
 
-  test "example interacts with things" do
-    inject = double
+  test "example outputs to console" do
+    inject = double(IO)
     |> allow(:puts, with: {:any, 1}, returns: :ok) # {:any, x} will accept any values of arity x
-    |> allow(:some_service, with: [1, 2, 3], returns: :ok) # strictly accepts these three arguments
 
     Example.process(inject)
 
     # now just use the built-in ExUnit methods assert_receive/refute_receive to verify things
     assert_receive({:puts, "It works without mocking libraries"})
-    assert_receive({:some_service, 1, 2, 3})
+  end
+end
+```
+
+### Map Doubles
+
+Maps can be useful if you want to group together functions from various modules as an injectable dependency.
+
+```elixir
+defmodule Example do
+  @inject %{
+    puts: &IO.puts/1,
+    another_service: &SomeService.process/3
+  }
+
+  def process(inject \\ @inject) do
+    # Note the dot placement for function calls is different from Module-based doubles.
+    inject.puts.("It works without mocking libraries")
+    inject.another_service.(1, 2, 3)
+  end
+end
+
+defmodule ExampleTest do
+  use ExUnit.Case
+  import Double
+
+  test "example test" do
+    inject = double()
+    |> allow(:puts, with: {:any, 1}, returns: :ok) # {:any, x} will accept any values of arity x
+    |> allow(:another_service, with: [1,2,3], returns: :ok) # requires exactly 1, 2, 3 arguments
+
+    Example.process(inject)
+
+    # now just use the built-in ExUnit methods assert_receive/refute_receive to verify things
+    assert_receive({:puts, "It works without mocking libraries"})
+    assert_receive({:another_service, 1, 2, 3})
+  end
+end
+```
+
+### Struct Doubles
+
+Using a struct behaves much like using maps, but has the benefit of throwing an error when trying to allow a non-existent key.
+Structs can also be handy for re-use if you share similar dependencies throughout your app.
+
+```elixir
+defmodule Example do
+  defmodule Inject do
+    defstruct puts: &IO.puts/1
+  end
+
+  def process(inject \\ %Inject{}) do
+    inject.puts.("It works without mocking libraries")
+  end
+end
+
+defmodule ExampleTest do
+  use ExUnit.Case
+  import Double
+
+  test "example test" do
+    inject = double(%Example.Inject{})
+    |> allow(:puts, with: {:any, 1}, returns: :ok) # {:any, x} will accept any values of arity x
+
+    Example.process(inject)
+
+    # now just use the built-in ExUnit methods assert_receive/refute_receive to verify things
+    assert_receive({:puts, "It works without mocking libraries"})
   end
 end
 ```
@@ -79,29 +118,29 @@ end
 ### Basics
 
 ```elixir
-# no return value or arguments
-double = double |> allow(:example)
-double.example.() #nil
+# minimal function - no return value or arguments
+stub = double(Application) |> allow(:started_applications)
+stub.started_applications() #nil
 
 # only accept specific arguments
-double = double |> allow(:example, with: ["hello world"])
-double.example.("hello world") # nil
+stub = double(Application) |> allow(:ensure_all_started, with: [:logger])
+stub.ensure_all_started(:logger) # nil
 
 # setup return value
-double = double |> allow(:example, with: ["hello world"], returns: :ok)
-double.example.("hello world") # :ok
+stub = double(IO) |> allow(:puts, with: ["hello world"], returns: :ok)
+stub.puts("hello world") # :ok
 
 # accept any arguments of specific arity
-double = double |> allow(:example, with: {:any, 2}, returns: :ok)
-double.example.("hello", "world") # :ok
+stub = double(ExampleModule) |> allow(:example, with: {:any, 2}, returns: :ok)
+stub.example("hello", "world") # :ok
 
 # stub as many functions as you want
-double = double
+stub = double(ExampleModule)
 |> allow(:example)
 |> allow(:another_example)
 
-# you can even add your own data or stubs to the map, it's just a normal map
-double = double
+# When using Map based doubles, you can add your own data or stubs, it's just a normal map
+stub = double
 |> Map.merge(%{some_value: "hello"})
 |> allow(:example)
 double.some_value # "hello"
@@ -110,40 +149,50 @@ double.example.() # nil
 
 ### Different return values for different arguments
 ```elixir
-double = double
+stub = double(ExampleModule)
 |> allow(:example, with: ["one"], returns: 1)
 |> allow(:example, with: ["two"], returns: 2)
 |> allow(:example, with: ["three"], returns: 3)
 
-double.example.("one") # 1
-double.example.("two") # 2
-double.example.("three") # 3
+stub.example("one") # 1
+stub.example("two") # 2
+stub.example("three") # 3
 ```
 
 ### Multiple calls returning different values
 ```elixir
-double = double
+stub = double(ExampleModule)
 |> allow(:example, with: ["count"], returns: 1, returns: 2)
 
-double.example.("count") # 1
-double.example.("count") # 2
-double.example.("count") # 2
+stub.example("count") # 1
+stub.example("count") # 2
+stub.example("count") # 2
 ```
 
-### Struct key verification
+### Exceptions
+
+```elixir
+double = double(ExampleModule)
+|> allow(:example_with_error_type, raises: {RuntimeError, "kaboom!"})
+|> allow(:example_with_message_only, raises: "kaboom!") # defaults to RuntimeError
+```
+
+### Verifying Doubles
+
+By default when using module doubles, your setups will check the source module to ensure the function exists with the correct arity.
+
+```elixir
+double(IO)
+|> allow(:non_existent_function, with: [1]) # raises VerifyingDoubleError
+```
+
+### Struct Key Verification
 
 ```elixir
 double = double(%MyStruct{})
 |> allow(:example, with: ["hello"], returns: "world") # will error if :example is not a key in MyStruct.
 ```
 
-### Exceptions
-
-```elixir
-double = double
-|> allow(:example_with_error_type, raises: {RuntimeError, "kaboom!"})
-|> allow(:example_with_message_only, raises: "kaboom!") # defaults to RuntimeError
-```
 ### Nested Doubles
 If you want to group some of your stubbed functions in a nested map, that works just like setting any other value in a map.
 ```elixir

--- a/lib/double.ex
+++ b/lib/double.ex
@@ -1,63 +1,90 @@
 defmodule Double do
   @moduledoc """
-  Double is a simple library to help build injectable dependencies for your tests.
+  Double builds on-the-fly injectable dependencies for your tests.
   It does NOT override behavior of existing modules or functions.
   """
 
   use GenServer
 
   @type option :: {:with, [...]} | {:returns, any} | {:raises, String.t | {atom, String.t}}
+  @type double_option :: {:verify, true | false}
 
   # API
 
-  @spec double :: map
-  @spec double(map | struct) :: map | struct
+  @spec double :: map :: atom
+  @spec double(map | struct | atom) :: map | struct | atom
+  @spec double(map | struct | atom, opts :: double_option) :: map | struct | atom
   @doc """
   Returns a map that can be used to setup stubbed functions.
   """
-  def double do
+  def double() do
     double(%{})
   end
   @doc """
-  Same as double/0 but returns the same map or struct given
+  Same as double/0 but can return structs and modules too
   """
-  def double(struct_or_map) do
+  def double(source, opts \\ [verify: true]) do
     Double.Registry.start
     test_pid = self()
     {:ok, pid} = GenServer.start_link(__MODULE__, [])
-    double_id = :crypto.hash(:sha, pid |> inspect) |> Base.encode16 |> String.downcase
-    Double.Registry.register_double(double_id, pid, test_pid)
-    Map.put(struct_or_map, :_double_id, double_id)
+    double_id = case is_atom(source) do
+      true ->
+        source_name = source |> Atom.to_string |> String.split(".") |> List.last
+        "#{source_name}Double#{:erlang.unique_integer([:positive])}"
+      false -> :crypto.hash(:sha, pid |> inspect) |> Base.encode16 |> String.downcase
+    end
+    Double.Registry.register_double(double_id, pid, test_pid, source, opts)
+    case is_atom(source) do
+      true -> double_id |> String.to_atom
+      false -> Map.put(source, :_double_id, double_id)
+    end
   end
 
   @doc """
-  Adds a stubbed function to the given map or struct.
-  Structs will only work if they contain the key given for function_name.
+  Adds a stubbed function to the given map, struct, or module.
+  Structs will fail if they are missing the key given for function_name.
+  Modules will fail if the function is not defined.
   """
-  @spec allow(map | struct, atom, [option]) :: map | struct
+  @spec allow(map | struct | atom, atom, [option]) :: map | struct
   def allow(dbl, function_name, opts) when is_list(opts) do
-    case dbl do
-      %{__struct__: _} ->
-        case Enum.member?(Map.keys(dbl), function_name) do
-          true -> do_allow(dbl, function_name, opts)
-          false -> struct_key_error(dbl, function_name)
-        end
-      _ -> do_allow(dbl, function_name, opts)
-    end
+    verify_mod_double(dbl, function_name, opts)
+    |> verify_struct_double(function_name)
+    |> do_allow(function_name, opts)
   end
+
   defp do_allow(dbl, function_name, opts) when is_list(opts) do
     return_values = Enum.reduce(opts, [], fn({k, v}, acc) ->
-      case k do
-        :returns -> acc ++ [v]
-        _ -> acc
-      end
+      if k == :returns, do: acc ++ [v], else: acc
     end)
     return_values = if return_values == [], do: [nil], else: return_values
     args = opts[:with] || []
     raises = opts[:raises]
-    pid = Double.Registry.whereis_double(dbl._double_id)
+    double_id = if is_atom(dbl), do: Atom.to_string(dbl), else: dbl._double_id
+    pid = Double.Registry.whereis_double(double_id)
     GenServer.call(pid, {:allow, dbl, function_name, args, return_values, raises})
   end
+
+  defp verify_mod_double(dbl, function_name, opts) when is_atom(dbl) do
+    double_opts = Double.Registry.opts_for("#{dbl}")
+    if double_opts[:verify] do
+      source = Double.Registry.source_for("#{dbl}")
+      source_functions = source.__info__(:functions)
+      stub_arity = arity(opts[:with])
+      matching_function = Enum.find(source_functions, fn({k, v}) ->
+        k == function_name && v == stub_arity
+      end)
+      if matching_function == nil do
+        raise VerifyingDoubleError, message: "The function '#{function_name}/#{stub_arity}' is not defined in TestModuleDouble"
+      end
+    end
+    dbl
+  end
+  defp verify_mod_double(dbl, _, _), do: dbl
+
+  defp verify_struct_double(%{__struct__: _} = dbl, function_name) do
+    if Enum.member?(Map.keys(dbl), function_name), do: dbl, else: struct_key_error(dbl, function_name)
+  end
+  defp verify_struct_double(dbl, _), do: dbl
 
   # SERVER
 
@@ -84,7 +111,12 @@ defmodule Double do
     stubs = stubs ++ Enum.map(return_values, fn(return_value) ->
       {function_name, args, return_value}
     end)
-    dbl = put_in(dbl, [function_name], stub_function(dbl._double_id, function_name, args, raises))
+    dbl = case is_atom(dbl) do
+      true ->
+        stub_module(dbl, stubs, raises)
+        dbl
+      false -> Map.put(dbl, function_name, stub_function(dbl._double_id, function_name, args, raises))
+    end
     {:reply, dbl, stubs}
   end
 
@@ -103,16 +135,64 @@ defmodule Double do
     match?({^function_name, {:any, _arity}, _return_value}, stub)
   end
 
+  defp stub_module(mod, stubs, raises) do
+    stubs = stubs |> Enum.uniq_by(fn({function_name, allowed_arguments, _}) ->
+     {function_name, arity(allowed_arguments)}
+    end)
+    code = """
+    defmodule :#{mod} do
+    """
+    code = Enum.reduce(stubs, code, fn({function_name, allowed_arguments, _}, acc) ->
+      {signature, message, error} = function_pieces(function_name, allowed_arguments, raises)
+      acc <> """
+        def #{function_name}(#{signature}) do
+          #{function_body(mod, message, function_name, signature, error)}
+        end
+      """
+    end)
+
+    code = code <> "\nend"
+    Code.compiler_options(ignore_module_conflict: true)
+    Code.eval_string(code)
+    Code.compiler_options(ignore_module_conflict: false)
+  end
+
   defp stub_function(double_id, function_name, allowed_arguments, raises) do
+    {signature, message, error_code} = function_pieces(function_name, allowed_arguments, raises)
+    function_string = """
+    fn(#{signature}) ->
+      #{function_body(double_id, message, function_name, signature, error_code)}
+    end
+    """
+    {result, _} = Code.eval_string(function_string)
+    result
+  end
+
+  defp function_body(double_id, message, function_name, signature, error_code) do
+    """
+    test_pid = Double.Registry.whereis_test(\"#{double_id}\")
+    send(test_pid, #{message})
+    pid = Double.Registry.whereis_double(\"#{double_id}\")
+    GenServer.call(pid, {:pop_function, :#{function_name}, [#{signature}]})
+    #{error_code}
+    """
+  end
+
+  defp arity(allowed_arguments) do
+    case allowed_arguments do
+      nil -> 0
+      {:any, arity} -> arity
+      _ -> Enum.count(allowed_arguments)
+    end
+  end
+
+  defp function_pieces(function_name, allowed_arguments, raises) do
     error_code = case raises do
       {error_type, msg} -> "raise #{error_type}, message: \"#{msg}\""
       msg when is_bitstring(msg) -> "raise \"#{msg}\""
       _ -> ""
     end
-    arity = case allowed_arguments do
-      {:any, arity} -> arity
-      _ -> Enum.count(allowed_arguments)
-    end
+    arity = arity(allowed_arguments)
     function_signature = case arity do
       0 -> ""
       _ -> Enum.map(0..arity - 1, fn(i) -> << 97 + i :: utf8 >> end) |> Enum.join(", ")
@@ -121,17 +201,7 @@ defmodule Double do
       "" -> ":#{function_name}"
       _ -> "{:#{function_name}, #{function_signature}}"
     end
-    function_string = """
-    fn(#{function_signature}) ->
-      test_pid = Double.Registry.whereis_test(\"#{double_id}\")
-      send(test_pid, #{message})
-      pid = Double.Registry.whereis_double(\"#{double_id}\")
-      GenServer.call(pid, {:pop_function, :#{function_name}, [#{function_signature}]})
-      #{error_code}
-    end
-    """
-    {result, _} = Code.eval_string(function_string)
-    result
+    {function_signature, message, error_code}
   end
 
   defp struct_key_error(dbl, key) do

--- a/lib/double/registry.ex
+++ b/lib/double/registry.ex
@@ -16,8 +16,16 @@ defmodule Double.Registry do
     GenServer.call(:registry, {:whereis_test, double_id})
   end
 
-  def register_double(double_id, pid, test_pid) do
-    GenServer.call(:registry, {:register_id, double_id, pid, test_pid})
+  def source_for(double_id) do
+    GenServer.call(:registry, {:source_for, double_id})
+  end
+
+  def opts_for(double_id) do
+    GenServer.call(:registry, {:opts_for, double_id})
+  end
+
+  def register_double(double_id, pid, test_pid, source, opts) do
+    GenServer.call(:registry, {:register_id, double_id, pid, test_pid, source, opts})
   end
 
   # SERVER
@@ -27,21 +35,29 @@ defmodule Double.Registry do
   end
 
   def handle_call({:whereis_double, double_id}, _from, state) do
-    {double_pid, _} = state
-    |> Map.get(double_id, {:undefined, nil})
+    {double_pid, _, _, _} = Map.get(state, double_id, {:undefined, nil, nil, nil})
     {:reply, double_pid, state}
   end
 
   def handle_call({:whereis_test, double_id}, _from, state) do
-    {_, test_pid} = state
-    |> Map.get(double_id, {:undefined, nil})
+    {_, test_pid, _, _} = Map.get(state, double_id, {:undefined, nil, nil, nil})
     {:reply, test_pid, state}
   end
 
-  def handle_call({:register_id, double_id, pid, test_pid}, _from, state) do
+  def handle_call({:source_for, double_id}, _from, state) do
+    {_, _, source, _} = Map.get(state, double_id, {:undefined, nil, nil, nil})
+    {:reply, source, state}
+  end
+
+  def handle_call({:opts_for, double_id}, _from, state) do
+    {_, _, _, opts} = Map.get(state, double_id, {:undefined, nil, nil, nil})
+    {:reply, opts, state}
+  end
+
+  def handle_call({:register_id, double_id, pid, test_pid, source, opts}, _from, state) do
     case Map.get(state, double_id) do
       nil ->
-        {:reply, :yes, Map.put(state, double_id, {pid, test_pid})}
+        {:reply, :yes, Map.put(state, double_id, {pid, test_pid, source, opts})}
 
       _ ->
         {:reply, :no, state}

--- a/lib/verifying_double_error.ex
+++ b/lib/verifying_double_error.ex
@@ -1,0 +1,3 @@
+defmodule VerifyingDoubleError do
+  defexception message: "The stubbed function is not defined in the source module."
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Double.Mixfile do
   use Mix.Project
-  @version "0.2.6"
+  @version "0.3.0"
 
   def project do
     [app: :double,

--- a/test/common_tests.ex
+++ b/test/common_tests.ex
@@ -1,0 +1,109 @@
+defmodule CommonTests do
+  defmacro test_double_behavior do
+    quote do
+      test "adds functions to maps", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: [1,2,3], returns: 1)
+        assert subject.(inject, :process, [1,2,3]) == 1
+        assert_receive({:process, 1, 2, 3})
+
+        inject = allow(inject, :another_function, with: [], returns: :anything)
+        assert subject.(inject, :another_function, []) == :anything
+        assert_receive(:another_function)
+      end
+
+      test "allows multiple calls", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: [1,2,3], returns: 1)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+      end
+
+      test "allows subsequent calls to return new values", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process,
+          with: [1,2,3],
+          returns: 1,
+          returns: 2,
+          returns: 3
+        )
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+        assert subject.(inject, :process, [1, 2, 3]) == 2
+        assert subject.(inject, :process, [1, 2, 3]) == 3
+        assert subject.(inject, :process, [1, 2, 3]) == 3
+      end
+
+      test "no return value is nil", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: [1,2,3])
+        assert subject.(inject, :process, [1, 2, 3]) == nil
+      end
+
+      test "allows any arguments", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+      end
+
+      test "stubbing specific arguments is given priority over {:any, x}", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
+        |> allow(:process, with: [1,2,3], returns: 2)
+        assert subject.(inject, :process, [1, 2, 3]) == 2
+        assert subject.(inject, :process, [1, 1, 1]) == 1
+      end
+
+      test "allows empty arguments", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: [], returns: 1)
+        assert subject.(inject, :process, []) == 1
+      end
+
+      test "without arguments setup defaults to none required", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, returns: :ok)
+        assert subject.(inject, :process, []) == :ok
+      end
+
+      test "allows out of order calls", %{dbl: dbl, subject: subject} do
+        inject = dbl
+        |> allow(:process, with: [1], returns: 1)
+        |> allow(:process, with: [2], returns: 2)
+        |> allow(:process, with: [3], returns: 3)
+        assert subject.(inject, :process, [2]) == 2
+        assert subject.(inject, :process, [1]) == 1
+        assert subject.(inject, :process, [3]) == 3
+        assert subject.(inject, :process, [3]) == 3
+      end
+
+      test "overwrites existing setup with same args", %{dbl: dbl, subject: subject} do
+        inject = dbl
+        |> allow(:process, with: [1], returns: 1)
+        |> allow(:process, with: [1], returns: 2)
+        assert subject.(inject, :process, [1]) == 2
+        assert subject.(inject, :process, [1]) == 2
+      end
+
+      test "multiple doubles", %{dbl: dbl, dbl2: dbl2, subject: subject} do
+        inject1 = dbl |> allow(:process, with: [], returns: 1)
+        inject2 = dbl2 |> allow(:process, with: [], returns: 2)
+        assert subject.(inject1, :process, []) == 1
+        assert subject.(inject2, :process, []) == 2
+      end
+
+      test "sets up exceptions with a type of exception", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, with: [], raises: {RuntimeError, "boom"})
+        assert_raise RuntimeError, "boom", fn ->
+          subject.(inject, :process, [])
+        end
+      end
+
+      test "sets up exceptions with only a message", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, with: [], raises: "boom")
+        assert_raise RuntimeError, "boom", fn ->
+          subject.(inject, :process, [])
+        end
+      end
+
+      test "handles multiple doubles with separate setups", %{dbl: dbl, dbl2: dbl2, subject: subject} do
+        double1 = dbl |> allow(:process, returns: 1)
+        double2 = dbl2 |> allow(:process, returns: 2)
+        assert subject.(double1, :process, []) == 1
+        assert subject.(double2, :process, []) == 2
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This feature allows doubles to be created from modules.

```elixir
io_stub = double(IO) |> allow(:puts, with: ["hello double"], returns: :ok)
io_stub.puts("hello double") # :ok
```

Module doubles are strict by default meaning they verify that the function exists on the source module.
```elixir
io_stub = double(IO) |> allow(:non_existent_function) # VerifyingDoubleError
```