### PR TITLE
New function stub syntax

### DIFF
--- a/lib/double.ex
+++ b/lib/double.ex
@@ -2,38 +2,49 @@ defmodule Double do
   @moduledoc """
   Double builds on-the-fly injectable dependencies for your tests.
   It does NOT override behavior of existing modules or functions.
+  Double uses Elixir's built-in language features such as pattern matching and message passing to
+  give you everything you would normally need a complex mocking tool for.
   """
 
+  alias Double.Registry
+  alias Double.FuncList
   use GenServer
 
-  @type option :: {:with, [...]} | {:returns, any} | {:raises, String.t | {atom, String.t}}
+  @default_options [verify: true]
+
+  @type allow_option :: {:with, [...]}
+    | {:returns, any}
+    | {:raises, String.t
+    | {atom, String.t}}
   @type double_option :: {:verify, true | false}
 
   # API
 
-  @spec double :: map :: atom
-  @spec double(map | struct | atom) :: map | struct | atom
-  @spec double(map | struct | atom, opts :: double_option) :: map | struct | atom
+  @spec double :: map
+  @spec double(struct, [double_option]) :: struct
+  @spec double(atom, [double_option]) :: atom
   @doc """
   Returns a map that can be used to setup stubbed functions.
   """
-  def double() do
-    double(%{})
-  end
+  def double, do: double(%{})
   @doc """
   Same as double/0 but can return structs and modules too
   """
-  def double(source, opts \\ [verify: true]) do
-    Double.Registry.start
+  def double(source, opts \\ @default_options) do
+    Registry.start
     test_pid = self()
     {:ok, pid} = GenServer.start_link(__MODULE__, [])
     double_id = case is_atom(source) do
       true ->
         source_name = source |> Atom.to_string |> String.split(".") |> List.last
         "#{source_name}Double#{:erlang.unique_integer([:positive])}"
-      false -> :crypto.hash(:sha, pid |> inspect) |> Base.encode16 |> String.downcase
+      false ->
+        :sha
+        |> :crypto.hash(inspect(pid))
+        |> Base.encode16
+        |> String.downcase
     end
-    Double.Registry.register_double(double_id, pid, test_pid, source, opts)
+    Registry.register_double(double_id, pid, test_pid, source, opts)
     case is_atom(source) do
       true -> double_id |> String.to_atom
       false -> Map.put(source, :_double_id, double_id)
@@ -45,31 +56,48 @@ defmodule Double do
   Structs will fail if they are missing the key given for function_name.
   Modules will fail if the function is not defined.
   """
-  @spec allow(map | struct | atom, atom, [option]) :: map | struct
-  def allow(dbl, function_name, opts) when is_list(opts) do
-    verify_mod_double(dbl, function_name, opts)
-    |> verify_struct_double(function_name)
-    |> do_allow(function_name, opts)
-  end
-
-  defp do_allow(dbl, function_name, opts) when is_list(opts) do
-    return_values = Enum.reduce(opts, [], fn({k, v}, acc) ->
+  @spec allow(any, atom, [function | [allow_option]]) :: struct | map | atom
+  def allow(dbl, function_name) when is_atom(function_name), do: allow(dbl, function_name, with: [])
+  def allow(dbl, function_name, func_opts) when is_list(func_opts) do
+    return_values = Enum.reduce(func_opts, [], fn({k, v}, acc) ->
       if k == :returns, do: acc ++ [v], else: acc
     end)
     return_values = if return_values == [], do: [nil], else: return_values
-    args = opts[:with] || []
-    raises = opts[:raises]
-    double_id = if is_atom(dbl), do: Atom.to_string(dbl), else: dbl._double_id
-    pid = Double.Registry.whereis_double(double_id)
-    GenServer.call(pid, {:allow, dbl, function_name, args, return_values, raises})
+    option_sets = return_values |> Enum.reduce([], fn(return_value, acc) ->
+      append_opts = func_opts
+      |> Keyword.take([:with, :raises])
+      |> Keyword.put(:returns, return_value)
+      acc ++ [append_opts]
+    end)
+    option_sets |> Enum.reduce(dbl, fn(opts, acc) ->
+      {func, _} = create_function_from_opts(opts)
+      allow(acc, function_name, func)
+    end)
+  end
+  def allow(dbl, function_name, func) when is_function(func) do
+    dbl
+    |> verify_mod_double(function_name, func)
+    |> verify_struct_double(function_name)
+    |> do_allow(function_name, func)
   end
 
-  defp verify_mod_double(dbl, function_name, opts) when is_atom(dbl) do
-    double_opts = Double.Registry.opts_for("#{dbl}")
+  @doc false
+  def func_list(pid) do
+    GenServer.call(pid, :func_list)
+  end
+
+  defp do_allow(dbl, function_name, func) do
+    double_id = if is_atom(dbl), do: Atom.to_string(dbl), else: dbl._double_id
+    pid = Registry.whereis_double(double_id)
+    GenServer.call(pid, {:allow, dbl, function_name, func})
+  end
+
+  defp verify_mod_double(dbl, function_name, func) when is_atom(dbl) do
+    double_opts = Registry.opts_for("#{dbl}")
     if double_opts[:verify] do
-      source = Double.Registry.source_for("#{dbl}")
+      source = Registry.source_for("#{dbl}")
       source_functions = source.__info__(:functions)
-      stub_arity = arity(opts[:with])
+      stub_arity = :erlang.fun_info(func)[:arity]
       matching_function = Enum.find(source_functions, fn({k, v}) ->
         k == function_name && v == stub_arity
       end)
@@ -82,71 +110,59 @@ defmodule Double do
   defp verify_mod_double(dbl, _, _), do: dbl
 
   defp verify_struct_double(%{__struct__: _} = dbl, function_name) do
-    if Enum.member?(Map.keys(dbl), function_name), do: dbl, else: struct_key_error(dbl, function_name)
+    if Enum.member?(Map.keys(dbl), function_name) do
+      dbl
+    else
+      struct_key_error(dbl, function_name)
+    end
   end
   defp verify_struct_double(dbl, _), do: dbl
 
   # SERVER
 
-  @doc false
-  def handle_call({:pop_function, function_name, args}, _from, stubs) do
-    matching_stubs = matching_stubs(stubs, function_name, args)
-    case matching_stubs do
-      [stub | other_matching_stubs] ->
-        # remove this stub from stack only if it's not the only matching one
-        stubs = if Enum.empty?(other_matching_stubs) do
-          stubs
-        else
-          List.delete(stubs, stub)
-        end
-        {_, _, return_value} = stub
-        {:reply, return_value, stubs}
-      [] -> {:reply, nil, stubs}
-    end
+  def init([]) do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    {:ok, %{func_list: pid}}
   end
 
   @doc false
-  def handle_call({:allow, dbl, function_name, args, return_values, raises}, _from, stubs) do
-    stubs = stubs |> Enum.reject(fn(stub) -> match?({^function_name, ^args, _return_value}, stub) end)
-    stubs = stubs ++ Enum.map(return_values, fn(return_value) ->
-      {function_name, args, return_value}
-    end)
+  def handle_call(:func_list, _from, state) do
+    {:reply, state.func_list, state}
+  end
+
+  @doc false
+  def handle_call({:allow, dbl, function_name, func}, _from, state) do
+    FuncList.push(state.func_list, function_name, func)
+
     dbl = case is_atom(dbl) do
       true ->
-        stub_module(dbl, stubs, raises)
+        stub_module(dbl, state)
         dbl
-      false -> Map.put(dbl, function_name, stub_function(dbl._double_id, function_name, args, raises))
+      false ->
+        dbl
+        |> Map.put(
+          function_name,
+          stub_function(dbl._double_id, function_name, func)
+        )
     end
-    {:reply, dbl, stubs}
+    {:reply, dbl, state}
   end
 
-  defp matching_stubs(stubs, function_name, args) do
-    Enum.filter(stubs, fn(stub) -> matching_stub?(stub, function_name, args) end)
-    |> Enum.sort_by(fn(stub) ->
-      case stub do
-        {_function_name, {:any, _arity}, _return_value} -> 1
-        _ -> 0
-      end
+  defp stub_module(mod, state) do
+    funcs = state.func_list
+    |> FuncList.list
+    |> Enum.uniq_by(fn({function_name, func}) ->
+     {function_name, arity(func)}
     end)
-  end
 
-  defp matching_stub?(stub, function_name, args) do
-    match?({^function_name, ^args, _return_value}, stub) ||
-    match?({^function_name, {:any, _arity}, _return_value}, stub)
-  end
-
-  defp stub_module(mod, stubs, raises) do
-    stubs = stubs |> Enum.uniq_by(fn({function_name, allowed_arguments, _}) ->
-     {function_name, arity(allowed_arguments)}
-    end)
     code = """
     defmodule :#{mod} do
     """
-    code = Enum.reduce(stubs, code, fn({function_name, allowed_arguments, _}, acc) ->
-      {signature, message, error} = function_pieces(function_name, allowed_arguments, raises)
+    code = Enum.reduce(funcs, code, fn({function_name, func}, acc) ->
+      {signature, message} = function_parts(function_name, func)
       acc <> """
         def #{function_name}(#{signature}) do
-          #{function_body(mod, message, function_name, signature, error)}
+          #{function_body(mod, message, function_name, signature)}
         end
       """
     end)
@@ -157,55 +173,84 @@ defmodule Double do
     Code.compiler_options(ignore_module_conflict: false)
   end
 
-  defp stub_function(double_id, function_name, allowed_arguments, raises) do
-    {signature, message, error_code} = function_pieces(function_name, allowed_arguments, raises)
-    function_string = """
+  defp stub_function(double_id, function_name, func) do
+    {signature, message} = function_parts(function_name, func)
+    func_str = """
     fn(#{signature}) ->
-      #{function_body(double_id, message, function_name, signature, error_code)}
+      #{function_body(double_id, message, function_name, signature)}
     end
     """
-    {result, _} = Code.eval_string(function_string)
+    {result, _} = Code.eval_string(func_str)
     result
   end
 
-  defp function_body(double_id, message, function_name, signature, error_code) do
+  defp function_body(double_id, message, function_name, signature) do
     """
     test_pid = Double.Registry.whereis_test(\"#{double_id}\")
     send(test_pid, #{message})
     pid = Double.Registry.whereis_double(\"#{double_id}\")
-    GenServer.call(pid, {:pop_function, :#{function_name}, [#{signature}]})
-    #{error_code}
+    func_list = Double.func_list(pid)
+    Double.FuncList.apply(func_list, :#{function_name}, [#{signature}])
     """
   end
 
-  defp arity(allowed_arguments) do
-    case allowed_arguments do
-      nil -> 0
-      {:any, arity} -> arity
-      _ -> Enum.count(allowed_arguments)
+  defp function_parts(function_name, func) do
+    signature = case arity(func) do
+      0 -> ""
+      x ->
+        0..(x - 1)
+        |> Enum.map(fn(i) -> << 97 + i :: utf8 >> end)
+        |> Enum.join(", ")
     end
+
+    message = case signature do
+      "" -> ":#{function_name}"
+      _ -> "{:#{function_name}, #{signature}}"
+    end
+    {signature, message}
   end
 
-  defp function_pieces(function_name, allowed_arguments, raises) do
-    error_code = case raises do
-      {error_type, msg} -> "raise #{error_type}, message: \"#{msg}\""
-      msg when is_bitstring(msg) -> "raise \"#{msg}\""
-      _ -> ""
-    end
-    arity = arity(allowed_arguments)
-    function_signature = case arity do
-      0 -> ""
-      _ -> Enum.map(0..arity - 1, fn(i) -> << 97 + i :: utf8 >> end) |> Enum.join(", ")
-    end
-    message = case function_signature do
-      "" -> ":#{function_name}"
-      _ -> "{:#{function_name}, #{function_signature}}"
-    end
-    {function_signature, message, error_code}
+  defp arity(func) do
+    :erlang.fun_info(func)[:arity]
   end
 
   defp struct_key_error(dbl, key) do
     msg = "The struct #{dbl.__struct__} does not contain key: #{key}. Use a Map if you want to add dynamic function names."
     raise ArgumentError, message: msg
+  end
+
+  defp create_function_from_opts(opts) do
+    args = case opts[:with] do
+      {:any, with_arity} ->
+        0..(with_arity - 1)
+        |> Enum.map(fn(i) -> << 97 + i :: utf8 >> |> String.to_atom end)
+        |> Enum.map(fn(arg_atom) -> {arg_atom, [], Elixir} end)
+      nil -> []
+      with_args -> with_args
+    end
+    args
+    |> quoted_fn(opts)
+    |> Code.eval_quoted
+  end
+
+  defp quoted_fn(args, opts) do
+    {:fn, [], [{:->, [], [args, quoted_fn_body(opts, opts[:raises])]}]}
+  end
+  defp quoted_fn_body(_opts, {error_module, message}) do
+    {
+      :raise,
+      [context: Elixir, import: Kernel],
+      [{:__aliases__, [alias: false], [error_module]}, message]
+    }
+  end
+  defp quoted_fn_body(_opts, message) when is_binary(message) do
+    {
+      :raise,
+      [context: Elixir, import: Kernel],
+      [message]
+    }
+  end
+  defp quoted_fn_body(opts, nil) do
+    opts[:returns]
   end
 end

--- a/lib/double/func_list.ex
+++ b/lib/double/func_list.ex
@@ -1,0 +1,92 @@
+defmodule Double.FuncList do
+  alias Double.FuncList
+  @moduledoc false
+
+  use GenServer
+
+  defstruct funcs: [], applied_funcs: [], dbl: nil
+
+  def init([]) do
+    {:ok, %FuncList{}}
+  end
+
+  def push(pid, function_name, func) when is_function(func) and is_atom(function_name) do
+    GenServer.call(pid, {:push, function_name, func})
+  end
+
+  def apply(pid, function_name, args) when is_atom(function_name) and is_list(args) do
+    state = GenServer.call(pid, :state)
+    funcs = state.funcs
+    |> Enum.filter(fn({func_name, _}) -> func_name == function_name end)
+    applied_funcs = state.applied_funcs
+    |> Enum.filter(fn({func_name, _}) -> func_name == function_name end)
+    verify_function_name_and_arity(funcs ++ applied_funcs, function_name, args)
+    return_value = case try_apply(funcs, args) do
+      :notfound ->
+        case try_apply(applied_funcs, args) do
+          :notfound ->
+            FunctionClauseError
+            |> raise(function: function_name, arity: Enum.count(args))
+          {:ok, return_value, _found} -> return_value
+        end
+      {:ok, return_value, found} ->
+        GenServer.call(pid, {:mark_applied, found})
+        return_value
+    end
+    return_value
+  end
+
+  def list(pid) do
+    GenServer.call(pid, :list)
+  end
+
+  def state(pid) do
+    GenServer.call(pid, :state)
+  end
+
+  # SERVER
+
+  def handle_call(:list, _from, state) do
+    {:reply, state.funcs ++ state.applied_funcs, state}
+  end
+
+  def handle_call(:state, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call({:push, function_name, func}, _from, state) do
+    state = %FuncList{state | funcs: state.funcs ++ [{function_name, func}]}
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:mark_applied, {func_name, func}}, _from, state) do
+    new_funcs = List.delete(state.funcs, {func_name, func})
+    state = case new_funcs == state.funcs do
+      true -> state
+      false ->
+        new_applied_funcs = [{func_name, func}] ++ state.applied_funcs
+        %FuncList{state | funcs: new_funcs, applied_funcs: new_applied_funcs}
+    end
+    {:reply, :ok, state}
+  end
+
+  defp try_apply([], _args), do: :notfound
+  defp try_apply([{func_name, func} | funcs], args) do
+    {:ok, apply(func, args), {func_name, func}}
+  rescue
+    BadArityError -> try_apply(funcs, args)
+    FunctionClauseError -> try_apply(funcs, args)
+  end
+
+  defp verify_function_name_and_arity(all_funcs, function_name, args) do
+    needed_arity = Enum.count(args)
+    matches = all_funcs
+    |> Enum.filter(fn({func_name, func}) ->
+      func_arity = :erlang.fun_info(func)[:arity]
+      func_name == function_name and func_arity == needed_arity
+    end)
+    if Enum.count(matches) == 0 do
+      raise UndefinedFunctionError, function: function_name, arity: needed_arity
+    end
+  end
+end

--- a/lib/double/registry.ex
+++ b/lib/double/registry.ex
@@ -1,4 +1,5 @@
 defmodule Double.Registry do
+  @moduledoc false
 
   use GenServer
 
@@ -25,7 +26,8 @@ defmodule Double.Registry do
   end
 
   def register_double(double_id, pid, test_pid, source, opts) do
-    GenServer.call(:registry, {:register_id, double_id, pid, test_pid, source, opts})
+    arg = {:register_id, double_id, pid, test_pid, source, opts}
+    GenServer.call(:registry, arg)
   end
 
   # SERVER
@@ -35,7 +37,8 @@ defmodule Double.Registry do
   end
 
   def handle_call({:whereis_double, double_id}, _from, state) do
-    {double_pid, _, _, _} = Map.get(state, double_id, {:undefined, nil, nil, nil})
+    {double_pid, _, _, _} = state
+    |> Map.get(double_id, {:undefined, nil, nil, nil})
     {:reply, double_pid, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Double.Mixfile do
   use Mix.Project
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [app: :double,
@@ -40,6 +40,7 @@ defmodule Double.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, "~> 0.4", only: [:dev], runtime: false},
+      {:credo, "~> 0.7.2", only: [:dev], runtime: false},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "credo": {:hex, :credo, "0.7.2", "850463f126c09227994967fdcf8b8ad7684ab220f7727c00bcafc0ac37bd3660", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -1,7 +1,9 @@
-Code.require_file("./test/common_tests.ex")
+Code.require_file("./test/keyword_syntax_tests.ex")
+Code.require_file("./test/function_syntax_tests.ex")
 defmodule DoubleTest do
   use ExUnit.Case, async: false
-  import CommonTests
+  import KeywordSyntaxTests
+  import FunctionSyntaxTests
   import Double
 
   defmodule TestStruct do
@@ -71,7 +73,8 @@ defmodule DoubleTest do
   describe "Map doubles" do
     setup [:maps]
 
-    test_double_behavior()
+    keyword_syntax_behavior()
+    function_syntax_behavior()
 
     test "keeps existing data in maps between stub calls", %{dbl: dbl, subject: subject} do
       inject = dbl
@@ -106,7 +109,8 @@ defmodule DoubleTest do
   describe "Struct doubles" do
     setup [:structs]
 
-    test_double_behavior()
+    keyword_syntax_behavior()
+    function_syntax_behavior()
 
     test "allow can stub a function for a struct", %{dbl: dbl, subject: subject} do
       dbl = allow(dbl, :io_puts, with: ["hello world"], returns: :ok)
@@ -125,7 +129,8 @@ defmodule DoubleTest do
   describe "Module doubles" do
     setup [:modules]
 
-    test_double_behavior()
+    keyword_syntax_behavior()
+    function_syntax_behavior()
 
     test "module names include source name", %{dbl: dbl} do
       assert "TestModuleDouble" <> _ = Atom.to_string(dbl)

--- a/test/func_list_test.exs
+++ b/test/func_list_test.exs
@@ -1,0 +1,91 @@
+defmodule FuncListTest do
+  alias Double.FuncList
+  use ExUnit.Case, async: true
+
+  test "raises UndefinedFunctionError when function is not defined" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    assert_raise UndefinedFunctionError, "function nil.function_name/1 is undefined or private", fn ->
+      FuncList.apply(pid, :function_name, [1])
+    end
+  end
+
+  test "raises UndefinedFunctionError when function arity is wrong" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(_x, _y, _z) -> 1 end)
+    assert_raise UndefinedFunctionError, "function nil.function_name/1 is undefined or private", fn ->
+      FuncList.apply(pid, :function_name, [1])
+    end
+  end
+
+  test "raises FunctionClauseError when function is defined, but args do not match" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(2) -> 1 end)
+    assert_raise FunctionClauseError, "no function clause matching in nil.function_name/1", fn ->
+      FuncList.apply(pid, :function_name, [1])
+    end
+  end
+
+  test "pushes and applys a function" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    assert FuncList.apply(pid, :function_name, [1]) == 1
+  end
+
+  test "allows multiple calls" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    assert FuncList.apply(pid, :function_name, [1]) == 1
+    assert FuncList.apply(pid, :function_name, [1]) == 1
+  end
+
+  test "allows subsequent calls to return new values" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    FuncList.push(pid, :function_name, fn(1) -> 2 end)
+    assert FuncList.apply(pid, :function_name, [1]) == 1
+    assert FuncList.apply(pid, :function_name, [1]) == 2
+    assert FuncList.apply(pid, :function_name, [1]) == 2
+  end
+
+  test "pushes functions with different names" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function1, fn(1) -> 1 end)
+    FuncList.push(pid, :function2, fn(1) -> 2 end)
+    assert FuncList.apply(pid, :function1, [1]) == 1
+    assert FuncList.apply(pid, :function2, [1]) == 2
+  end
+
+  test "properly uses pattern matching" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :tuple_match, fn({:test, x}) -> x end)
+    assert FuncList.apply(pid, :tuple_match, [{:test, 1}]) == 1
+
+    FuncList.push(pid, :map_match, fn(%{test: x}) -> x end)
+    assert FuncList.apply(pid, :map_match, [%{test: 1}]) == 1
+  end
+
+  test "works with zero arguments" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn() -> 1 end)
+    assert FuncList.apply(pid, :function_name, []) == 1
+  end
+
+  test "allows out of order calls" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    FuncList.push(pid, :function_name, fn(2) -> 2 end)
+    FuncList.push(pid, :function_name, fn(3) -> 3 end)
+    assert FuncList.apply(pid, :function_name, [2]) == 2
+    assert FuncList.apply(pid, :function_name, [1]) == 1
+    assert FuncList.apply(pid, :function_name, [3]) == 3
+    assert FuncList.apply(pid, :function_name, [3]) == 3
+  end
+
+  test "raises exceptions properly" do
+    {:ok, pid} = GenServer.start_link(FuncList, [])
+    FuncList.push(pid, :function_name, fn -> raise "Test Error" end)
+    assert_raise RuntimeError, "Test Error", fn ->
+      FuncList.apply(pid, :function_name, [])
+    end
+  end
+end

--- a/test/function_syntax_tests.ex
+++ b/test/function_syntax_tests.ex
@@ -1,0 +1,91 @@
+defmodule FunctionSyntaxTests do
+  defmacro function_syntax_behavior do
+    quote do
+      test "function syntax stubs functions", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, fn(1,2,3) -> 1 end)
+        assert subject.(inject, :process, [1,2,3]) == 1
+        assert_receive({:process, 1, 2, 3})
+
+        inject = allow(inject, :another_function, fn -> :anything end)
+        assert subject.(inject, :another_function, []) == :anything
+        assert_receive(:another_function)
+      end
+
+      test "function syntax allows multiple calls", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, fn(1,2,3) -> 1 end)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+      end
+
+      test "function syntax allows subsequent calls to return new values", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, fn(1,2,3) -> 1 end)
+        inject = allow(dbl, :process, fn(1,2,3) -> 2 end)
+        inject = allow(dbl, :process, fn(1,2,3) -> 3 end)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+        assert subject.(inject, :process, [1, 2, 3]) == 2
+        assert subject.(inject, :process, [1, 2, 3]) == 3
+        assert subject.(inject, :process, [1, 2, 3]) == 3
+      end
+
+      test "function syntax works in tandem with {:any, x}", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
+        |> allow(:process, fn(1,2,3) -> 2 end)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
+        assert subject.(inject, :process, [1, 2, 3]) == 2
+        assert subject.(inject, :process, [1, 1, 1]) == 1
+      end
+
+      test "function syntax with out of order calls", %{dbl: dbl, subject: subject} do
+        inject = dbl
+        |> allow(:process, fn(1) -> 1 end)
+        |> allow(:process, fn(2) -> 2 end)
+        |> allow(:process, fn(3) -> 3 end)
+        assert subject.(inject, :process, [2]) == 2
+        assert subject.(inject, :process, [1]) == 1
+        assert subject.(inject, :process, [3]) == 3
+        assert subject.(inject, :process, [3]) == 3
+      end
+
+      test "function syntax does not overwrite existing setup with same args", %{dbl: dbl, subject: subject} do
+        inject = dbl
+        |> allow(:process, fn(1) -> 1 end)
+        |> allow(:process, fn(1) -> 2 end)
+        assert subject.(inject, :process, [1]) == 1
+        assert subject.(inject, :process, [1]) == 2
+      end
+
+      test "function syntax works with pinned argument variables", %{dbl: dbl, subject: subject} do
+        arg1 = "test"
+        inject = dbl
+        |> allow(:process, fn(^arg1) -> arg1 end)
+        assert subject.(inject, :process, ["test"]) == "test"
+      end
+
+      test "function syntax exceptions with a type of exception", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, fn -> raise RuntimeError, "boom" end)
+        assert_raise RuntimeError, "boom", fn ->
+          subject.(inject, :process, [])
+        end
+      end
+
+      test "function syntax sets up exceptions with only a message", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, fn -> raise "boom" end)
+        assert_raise RuntimeError, "boom", fn ->
+          subject.(inject, :process, [])
+        end
+      end
+
+      test "function syntax multiple doubles", %{dbl: dbl, dbl2: dbl2, subject: subject} do
+        inject1 = dbl |> allow(:process, fn -> 1 end)
+        inject2 = dbl2 |> allow(:process, fn -> 2 end)
+        assert subject.(inject1, :process, []) == 1
+        assert subject.(inject2, :process, []) == 2
+      end
+
+      test "function syntax calling other modules", %{dbl: dbl, subject: subject} do
+        inject = dbl |> allow(:process, fn -> :rand.uniform end)
+        refute subject.(inject, :process, []) == subject.(inject, :process, [])
+      end
+    end
+  end
+end

--- a/test/keyword_syntax_tests.ex
+++ b/test/keyword_syntax_tests.ex
@@ -1,7 +1,13 @@
-defmodule CommonTests do
-  defmacro test_double_behavior do
+defmodule KeywordSyntaxTests do
+  defmacro keyword_syntax_behavior do
     quote do
-      test "adds functions to maps", %{dbl: dbl, subject: subject} do
+      test "keyword syntax without options, returns nil", %{dbl: dbl, subject: subject} do
+        inject = allow(dbl, :process)
+        assert subject.(inject, :process, []) == nil
+        assert_receive(:process)
+      end
+
+      test "keyword syntax stubs functions", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: [1,2,3], returns: 1)
         assert subject.(inject, :process, [1,2,3]) == 1
         assert_receive({:process, 1, 2, 3})
@@ -11,13 +17,13 @@ defmodule CommonTests do
         assert_receive(:another_function)
       end
 
-      test "allows multiple calls", %{dbl: dbl, subject: subject} do
+      test "keyword syntax allows multiple calls", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: [1,2,3], returns: 1)
         assert subject.(inject, :process, [1, 2, 3]) == 1
         assert subject.(inject, :process, [1, 2, 3]) == 1
       end
 
-      test "allows subsequent calls to return new values", %{dbl: dbl, subject: subject} do
+      test "keyword syntax allows subsequent calls to return new values", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process,
           with: [1,2,3],
           returns: 1,
@@ -30,34 +36,35 @@ defmodule CommonTests do
         assert subject.(inject, :process, [1, 2, 3]) == 3
       end
 
-      test "no return value is nil", %{dbl: dbl, subject: subject} do
+      test "keyword syntax with no return value is nil", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: [1,2,3])
         assert subject.(inject, :process, [1, 2, 3]) == nil
       end
 
-      test "allows any arguments", %{dbl: dbl, subject: subject} do
+      test "keyword syntax allows any arguments", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
         assert subject.(inject, :process, [1, 2, 3]) == 1
       end
 
-      test "stubbing specific arguments is given priority over {:any, x}", %{dbl: dbl, subject: subject} do
+      test "keyword syntax stubbing specific arguments works in tandem with {:any, x}", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
         |> allow(:process, with: [1,2,3], returns: 2)
+        assert subject.(inject, :process, [1, 2, 3]) == 1
         assert subject.(inject, :process, [1, 2, 3]) == 2
         assert subject.(inject, :process, [1, 1, 1]) == 1
       end
 
-      test "allows empty arguments", %{dbl: dbl, subject: subject} do
+      test "keyword syntax allows empty arguments", %{dbl: dbl, subject: subject} do
         inject = allow(dbl, :process, with: [], returns: 1)
         assert subject.(inject, :process, []) == 1
       end
 
-      test "without arguments setup defaults to none required", %{dbl: dbl, subject: subject} do
+      test "keyword syntax without arguments setup defaults to none required", %{dbl: dbl, subject: subject} do
         inject = dbl |> allow(:process, returns: :ok)
         assert subject.(inject, :process, []) == :ok
       end
 
-      test "allows out of order calls", %{dbl: dbl, subject: subject} do
+      test "keyword syntax allows out of order calls", %{dbl: dbl, subject: subject} do
         inject = dbl
         |> allow(:process, with: [1], returns: 1)
         |> allow(:process, with: [2], returns: 2)
@@ -68,42 +75,34 @@ defmodule CommonTests do
         assert subject.(inject, :process, [3]) == 3
       end
 
-      test "overwrites existing setup with same args", %{dbl: dbl, subject: subject} do
+      test "keyword syntax does not overwrite existing setup with same args", %{dbl: dbl, subject: subject} do
         inject = dbl
         |> allow(:process, with: [1], returns: 1)
         |> allow(:process, with: [1], returns: 2)
-        assert subject.(inject, :process, [1]) == 2
+        assert subject.(inject, :process, [1]) == 1
         assert subject.(inject, :process, [1]) == 2
       end
 
-      test "multiple doubles", %{dbl: dbl, dbl2: dbl2, subject: subject} do
+      test "keyword syntax with multiple doubles", %{dbl: dbl, dbl2: dbl2, subject: subject} do
         inject1 = dbl |> allow(:process, with: [], returns: 1)
         inject2 = dbl2 |> allow(:process, with: [], returns: 2)
         assert subject.(inject1, :process, []) == 1
         assert subject.(inject2, :process, []) == 2
       end
 
-      test "sets up exceptions with a type of exception", %{dbl: dbl, subject: subject} do
+      test "keyword syntax sets up exceptions with a type of exception", %{dbl: dbl, subject: subject} do
         inject = dbl |> allow(:process, with: [], raises: {RuntimeError, "boom"})
         assert_raise RuntimeError, "boom", fn ->
           subject.(inject, :process, [])
         end
       end
 
-      test "sets up exceptions with only a message", %{dbl: dbl, subject: subject} do
+      test "keyword syntax sets up exceptions with only a message", %{dbl: dbl, subject: subject} do
         inject = dbl |> allow(:process, with: [], raises: "boom")
         assert_raise RuntimeError, "boom", fn ->
           subject.(inject, :process, [])
         end
       end
-
-      test "handles multiple doubles with separate setups", %{dbl: dbl, dbl2: dbl2, subject: subject} do
-        double1 = dbl |> allow(:process, returns: 1)
-        double2 = dbl2 |> allow(:process, returns: 2)
-        assert subject.(double1, :process, []) == 1
-        assert subject.(double2, :process, []) == 2
-      end
-
     end
   end
 end


### PR DESCRIPTION
Resolves #13 

This provides a much more powerful and simple interface for stubbing functions.  Just pass anonymous ones!
```elixir
stub = double(IO) |> allow(:puts, fn(_msg) -> :ok end)
stub.puts("hello world")
assert_receive({:puts, "hello world"})
```
All of the old syntax still works too as well as module verification.  It's backwards compatible. 

Having said that, this was quite the code overhaul.  