### PR TITLE
Support for erlang modules

### DIFF
--- a/lib/double.ex
+++ b/lib/double.ex
@@ -96,7 +96,7 @@ defmodule Double do
     double_opts = Registry.opts_for("#{dbl}")
     if double_opts[:verify] do
       source = Registry.source_for("#{dbl}")
-      source_functions = source.__info__(:functions)
+      source_functions = :erlang.get_module_info(source, :functions)
       stub_arity = :erlang.fun_info(func)[:arity]
       matching_function = Enum.find(source_functions, fn({k, v}) ->
         k == function_name && v == stub_arity

--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -68,6 +68,10 @@ defmodule DoubleTest do
     test "stubs modules" do
       assert double(IO) |> is_atom
     end
+
+    test "stubs erlang modules" do
+      assert double(:application) |> is_atom
+    end
   end
 
   describe "Map doubles" do
@@ -146,6 +150,12 @@ defmodule DoubleTest do
       dbl = double(TestModule, verify: false)
       allow(dbl, :non_existent_function, with: {:any, 1}, returns: 1)
       assert dbl.non_existent_function(1) == 1
+    end
+
+    test "works with erlang modules" do
+      dbl = double(:application, verify: true)
+      |> allow(:loaded_applications, fn -> :ok end)
+      assert dbl.loaded_applications() == :ok
     end
   end
 


### PR DESCRIPTION
This resolves the issue of using module doubles on Erlang based modules by using `:erlang.get_module_info` rather than the `.__info__` functions.  