### PR TITLE
Using module_info over :erlang.get_module_info

### DIFF
--- a/lib/double.ex
+++ b/lib/double.ex
@@ -96,7 +96,7 @@ defmodule Double do
     double_opts = Registry.opts_for("#{dbl}")
     if double_opts[:verify] do
       source = Registry.source_for("#{dbl}")
-      source_functions = :erlang.get_module_info(source, :functions)
+      source_functions = source.module_info(:functions)
       stub_arity = :erlang.fun_info(func)[:arity]
       matching_function = Enum.find(source_functions, fn({k, v}) ->
         k == function_name && v == stub_arity

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Double.Mixfile do
   use Mix.Project
-  @version "0.4.2"
+  @version "0.4.3"
 
   def project do
     [app: :double,

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Double.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
+     elixirc_paths: elixirc_paths(Mix.env),
      docs: [
        extras: ["README.md"],
        main: "readme",
@@ -26,6 +27,9 @@ defmodule Double.Mixfile do
   def application do
     [applications: [:logger]]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   # Dependencies can be Hex packages:
   #

--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -13,16 +13,6 @@ defmodule DoubleTest do
               another_function: &:timer.sleep/1
   end
 
-  defmodule TestModule do
-    def io_puts(x), do: x
-    def sleep(x), do: x
-    def process, do: nil
-    def process(x), do: x
-    def process(x, y, z), do: {x,y,z}
-    def another_function,  do: nil
-    def another_function(x), do: x
-  end
-
   defp maps(context) do
     context
     |> Map.merge(%{

--- a/test/support/test_module.ex
+++ b/test/support/test_module.ex
@@ -1,0 +1,10 @@
+defmodule TestModule do
+  def io_puts(x), do: x
+  def sleep(x), do: x
+  def process, do: nil
+  def process(x), do: x
+  def process(x, y, z), do: {x,y,z}
+  def another_function,  do: nil
+  def another_function(x), do: x
+end
+


### PR DESCRIPTION
Resolves #17 

It appears that when a module isn't directly required or defined within the test file being run, using `:erlang.get_module_info` fails as if the source isn't a module at all.  I've recreated the issue by moving our TestModule into its own file.  

As reported in the issue, just using `.module_info` seems to alleviate the error and all tests are passing.  This seems like a good fix!