### PR TITLE
Behaviour doubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ The package can be installed as:
 
 ## Usage
 
-### Module Doubles
+### Module/Behaviour Doubles
 
 Module doubles are probably the most straightforward way to use Double.
 You're just creating fake versions of an existing module.
 You can use this module like any other module that you call functions on.
+Module doubles will verify that the module you're creating a double for defines the function you're stubbing with the correct arity.
+If your module defines a behaviour, your stubs will be verified against those callbacks with the same function name and arity checking.
 
 ```elixir
 defmodule Example do

--- a/lib/double.ex
+++ b/lib/double.ex
@@ -97,6 +97,12 @@ defmodule Double do
     if double_opts[:verify] do
       source = Registry.source_for("#{dbl}")
       source_functions = source.module_info(:functions)
+      source_functions = case source_functions[:behaviour_info] do
+        nil -> source_functions
+        _ ->
+          behaviours = source.behaviour_info(:callbacks)
+          source_functions |> Keyword.merge(behaviours)
+      end
       stub_arity = :erlang.fun_info(func)[:arity]
       matching_function = Enum.find(source_functions, fn({k, v}) ->
         k == function_name && v == stub_arity

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Double.Mixfile do
   use Mix.Project
-  @version "0.4.3"
+  @version "0.5.0"
 
   def project do
     [app: :double,

--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -147,6 +147,21 @@ defmodule DoubleTest do
       |> allow(:loaded_applications, fn -> :ok end)
       assert dbl.loaded_applications() == :ok
     end
+
+    test "verifies valid behavior doubles" do
+      dbl = TestBehaviour
+      |> double
+      |> allow(:process, fn(nil) -> :ok end)
+
+      assert :ok = dbl.process(nil)
+    end
+
+    test "verifies invalid behaviour doubles" do
+      dbl = TestBehaviour |> double
+      assert_raise VerifyingDoubleError, ~r/The function 'non_existent_function\/1' is not defined in :TestBehaviourDouble/, fn ->
+        allow(dbl, :non_existent_function, fn(_) -> :ok end)
+      end
+    end
   end
 
   test "works normally when called within another process" do

--- a/test/support/test_behaviour.ex
+++ b/test/support/test_behaviour.ex
@@ -1,0 +1,4 @@
+defmodule TestBehaviour do
+  @callback process(String.t) :: :ok
+end
+


### PR DESCRIPTION
This change allows modules with behaviours defined to be used as the source for a double.  The verification will include any callbacks functions as the set of functions to verify against.  