### PR TITLE
Start essential processes as a part of OTP application

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ The package can be installed as:
 
 ## Usage
 
+Start Double in your `test/test_helper.exs` file:
+
+```elixir
+ExUnit.start
+Application.ensure_all_started(:double)
+```
+
 ### Module/Behaviour Doubles
 
 Module doubles are probably the most straightforward way to use Double.

--- a/lib/double.ex
+++ b/lib/double.ex
@@ -31,7 +31,6 @@ defmodule Double do
   Same as double/0 but can return structs and modules too
   """
   def double(source, opts \\ @default_options) do
-    Registry.start
     test_pid = self()
     {:ok, pid} = GenServer.start_link(__MODULE__, [])
     double_id = case is_atom(source) do

--- a/lib/double/application.ex
+++ b/lib/double/application.ex
@@ -1,0 +1,16 @@
+defmodule Double.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      worker(Double.Registry, []),
+      worker(Double.Eval, [])
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end

--- a/lib/double/eval.ex
+++ b/lib/double/eval.ex
@@ -7,8 +7,11 @@ defmodule Double.Eval do
 
   use GenServer
 
-  def eval(code) do
+  def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def eval(code) do
     GenServer.call(__MODULE__, {:eval, code})
   end
 

--- a/lib/double/registry.ex
+++ b/lib/double/registry.ex
@@ -5,6 +5,10 @@ defmodule Double.Registry do
 
   # API
 
+  def start_link do
+    GenServer.start_link(__MODULE__, nil, name: :registry)
+  end
+
   def start do
     GenServer.start(__MODULE__, nil, name: :registry)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,10 @@ defmodule Double.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [
+      applications: [:logger],
+      mod: {Double.Application, []}
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Running `Double.Registry` and `Double.Eval` is essential for `Double`
to work correctly. This commit converts `double` to OTP application and
starts these processes as a part of supervision tree. This should prevent
occasional test failure, caused by stopping of `Double.Eval` between tests.