### PR TITLE
Fix Elixir 1.6 warnings

### DIFF
--- a/lib/double/eval.ex
+++ b/lib/double/eval.ex
@@ -15,6 +15,10 @@ defmodule Double.Eval do
     GenServer.call(__MODULE__, {:eval, code})
   end
 
+  def init(initial) do
+    {:ok, initial}
+  end
+
   def handle_call({:eval, code}, _from, state) do
     Code.compiler_options(ignore_module_conflict: true)
     Code.eval_string(code)

--- a/lib/double/registry.ex
+++ b/lib/double/registry.ex
@@ -37,12 +37,14 @@ defmodule Double.Registry do
   # SERVER
 
   def init(_) do
-    {:ok, Map.new}
+    {:ok, Map.new()}
   end
 
   def handle_call({:whereis_double, double_id}, _from, state) do
-    {double_pid, _, _, _} = state
-    |> Map.get(double_id, {:undefined, nil, nil, nil})
+    {double_pid, _, _, _} =
+      state
+      |> Map.get(double_id, {:undefined, nil, nil, nil})
+
     {:reply, double_pid, state}
   end
 

--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -1,5 +1,6 @@
 Code.require_file("./test/keyword_syntax_tests.ex")
 Code.require_file("./test/function_syntax_tests.ex")
+
 defmodule DoubleTest do
   use ExUnit.Case, async: false
   import KeywordSyntaxTests
@@ -18,7 +19,7 @@ defmodule DoubleTest do
     |> Map.merge(%{
       dbl: double(),
       dbl2: double(),
-      subject: fn(dbl, function_name, args) ->
+      subject: fn dbl, function_name, args ->
         apply(dbl[function_name], args)
       end
     })
@@ -29,7 +30,7 @@ defmodule DoubleTest do
     |> Map.merge(%{
       dbl: double(TestModule),
       dbl2: double(TestModule),
-      subject: fn(dbl, function_name, args) ->
+      subject: fn dbl, function_name, args ->
         apply(dbl, function_name, args)
       end
     })
@@ -40,7 +41,7 @@ defmodule DoubleTest do
     |> Map.merge(%{
       dbl: double(%TestStruct{}),
       dbl2: double(%TestStruct{}),
-      subject: fn(dbl, function_name, args) ->
+      subject: fn dbl, function_name, args ->
         apply(Map.get(dbl, function_name), args)
       end
     })
@@ -71,11 +72,13 @@ defmodule DoubleTest do
     function_syntax_behavior()
 
     test "keeps existing data in maps between stub calls", %{dbl: dbl, subject: subject} do
-      inject = dbl
-      |> Map.merge(%{im_here: 1})
-      |> allow(:process, with: [], returns: 1)
-      |> put_in([:dont_kill_me], 1)
-      |> allow(:hello, with: [], returns: "world")
+      inject =
+        dbl
+        |> Map.merge(%{im_here: 1})
+        |> allow(:process, with: [], returns: 1)
+        |> put_in([:dont_kill_me], 1)
+        |> allow(:hello, with: [], returns: "world")
+
       assert inject.dont_kill_me == 1
       assert inject.im_here == 1
       assert subject.(inject, :process, []) == 1
@@ -83,21 +86,25 @@ defmodule DoubleTest do
     end
 
     test "nesting the stub is possible", %{dbl: dbl, dbl2: dbl2, subject: subject} do
-      inject = allow(dbl, :process, with: [], returns: 1)
-      |> Map.put(:logger, dbl2
-        |> allow(:error, with: ["boom"], returns: :ok)
-      )
+      inject =
+        allow(dbl, :process, with: [], returns: 1)
+        |> Map.put(
+          :logger,
+          dbl2
+          |> allow(:error, with: ["boom"], returns: :ok)
+        )
+
       assert subject.(inject, :process, []) == 1
       assert subject.(inject.logger, :error, ["boom"]) == :ok
     end
 
     test "respects arity on any args", %{dbl: dbl, subject: subject} do
       inject = allow(dbl, :process, with: {:any, 3}, returns: 1)
+
       assert_raise BadArityError, fn ->
         subject.(inject, :process, [1]) == 1
       end
     end
-
   end
 
   describe "Struct doubles" do
@@ -113,10 +120,12 @@ defmodule DoubleTest do
     end
 
     test "stubbing a struct with an unknown key fails", %{dbl: dbl, subject: subject} do
-      assert_raise ArgumentError, "The struct Elixir.DoubleTest.TestStruct does not contain key: boom. Use a Map if you want to add dynamic function names.", fn ->
-        dbl = allow(dbl, :boom, with: [1], returns: :ok)
-        assert subject.(dbl, :boom, [1]) == :ok
-      end
+      assert_raise ArgumentError,
+                   "The struct Elixir.DoubleTest.TestStruct does not contain key: boom. Use a Map if you want to add dynamic function names.",
+                   fn ->
+                     dbl = allow(dbl, :boom, with: [1], returns: :ok)
+                     assert subject.(dbl, :boom, [1]) == :ok
+                   end
     end
   end
 
@@ -131,9 +140,11 @@ defmodule DoubleTest do
     end
 
     test "module doubles are strict by default", %{dbl: dbl} do
-      assert_raise VerifyingDoubleError, ~r/The function 'non_existent_function\/1' is not defined in :TestModuleDouble/, fn ->
-        allow(dbl, :non_existent_function, with: {:any, 1}, returns: 1)
-      end
+      assert_raise VerifyingDoubleError,
+                   ~r/The function 'non_existent_function\/1' is not defined in :TestModuleDouble/,
+                   fn ->
+                     allow(dbl, :non_existent_function, with: {:any, 1}, returns: 1)
+                   end
     end
 
     test "verification can be turned off" do
@@ -143,36 +154,45 @@ defmodule DoubleTest do
     end
 
     test "works with erlang modules" do
-      dbl = double(:application, verify: true)
-      |> allow(:loaded_applications, fn -> :ok end)
+      dbl =
+        double(:application, verify: true)
+        |> allow(:loaded_applications, fn -> :ok end)
+
       assert dbl.loaded_applications() == :ok
     end
 
     test "verifies valid behavior doubles" do
-      dbl = TestBehaviour
-      |> double
-      |> allow(:process, fn(nil) -> :ok end)
+      dbl =
+        TestBehaviour
+        |> double
+        |> allow(:process, fn nil -> :ok end)
 
       assert :ok = dbl.process(nil)
     end
 
     test "verifies invalid behaviour doubles" do
       dbl = TestBehaviour |> double
-      assert_raise VerifyingDoubleError, ~r/The function 'non_existent_function\/1' is not defined in :TestBehaviourDouble/, fn ->
-        allow(dbl, :non_existent_function, fn(_) -> :ok end)
-      end
+
+      assert_raise VerifyingDoubleError,
+                   ~r/The function 'non_existent_function\/1' is not defined in :TestBehaviourDouble/,
+                   fn ->
+                     allow(dbl, :non_existent_function, fn _ -> :ok end)
+                   end
     end
 
     test "works with modules having macros" do
-      dbl = Logger
-      |> double
-      |> allow(:info, fn(_msg) -> :ok end) # Logger.info/1 is a macro
+      # Logger.info/1 is a macro
+      dbl =
+        Logger
+        |> double
+        |> allow(:info, fn _msg -> :ok end)
 
       assert :ok = dbl.info(nil)
 
-      dbl = Mix.Task
-      |> double
-      |> allow(:run, fn(_, _) -> :ok end)
+      dbl =
+        Mix.Task
+        |> double
+        |> allow(:run, fn _, _ -> :ok end)
 
       assert :ok = dbl.run(nil, nil)
     end
@@ -180,9 +200,11 @@ defmodule DoubleTest do
 
   test "works normally when called within another process" do
     inject = double() |> allow(:some_function, with: [], returns: :ok)
-    spawn fn ->
+
+    spawn(fn ->
       inject.some_function.()
-    end
+    end)
+
     assert_receive :some_function
   end
 end

--- a/test/func_list_test.exs
+++ b/test/func_list_test.exs
@@ -4,22 +4,29 @@ defmodule FuncListTest do
 
   test "raises UndefinedFunctionError when function is not defined" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    assert_raise UndefinedFunctionError, "function nil.function_name/1 is undefined or private", fn ->
-      FuncList.apply(pid, :function_name, [1])
-    end
+
+    assert_raise UndefinedFunctionError,
+                 "function nil.function_name/1 is undefined or private",
+                 fn ->
+                   FuncList.apply(pid, :function_name, [1])
+                 end
   end
 
   test "raises UndefinedFunctionError when function arity is wrong" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(_x, _y, _z) -> 1 end)
-    assert_raise UndefinedFunctionError, "function nil.function_name/1 is undefined or private", fn ->
-      FuncList.apply(pid, :function_name, [1])
-    end
+    FuncList.push(pid, :function_name, fn _x, _y, _z -> 1 end)
+
+    assert_raise UndefinedFunctionError,
+                 "function nil.function_name/1 is undefined or private",
+                 fn ->
+                   FuncList.apply(pid, :function_name, [1])
+                 end
   end
 
   test "raises FunctionClauseError when function is defined, but args do not match" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(2) -> 1 end)
+    FuncList.push(pid, :function_name, fn 2 -> 1 end)
+
     assert_raise FunctionClauseError, "no function clause matching in nil.function_name/1", fn ->
       FuncList.apply(pid, :function_name, [1])
     end
@@ -27,21 +34,21 @@ defmodule FuncListTest do
 
   test "pushes and applys a function" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    FuncList.push(pid, :function_name, fn 1 -> 1 end)
     assert FuncList.apply(pid, :function_name, [1]) == 1
   end
 
   test "allows multiple calls" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(1) -> 1 end)
+    FuncList.push(pid, :function_name, fn 1 -> 1 end)
     assert FuncList.apply(pid, :function_name, [1]) == 1
     assert FuncList.apply(pid, :function_name, [1]) == 1
   end
 
   test "allows subsequent calls to return new values" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(1) -> 1 end)
-    FuncList.push(pid, :function_name, fn(1) -> 2 end)
+    FuncList.push(pid, :function_name, fn 1 -> 1 end)
+    FuncList.push(pid, :function_name, fn 1 -> 2 end)
     assert FuncList.apply(pid, :function_name, [1]) == 1
     assert FuncList.apply(pid, :function_name, [1]) == 2
     assert FuncList.apply(pid, :function_name, [1]) == 2
@@ -49,32 +56,32 @@ defmodule FuncListTest do
 
   test "pushes functions with different names" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function1, fn(1) -> 1 end)
-    FuncList.push(pid, :function2, fn(1) -> 2 end)
+    FuncList.push(pid, :function1, fn 1 -> 1 end)
+    FuncList.push(pid, :function2, fn 1 -> 2 end)
     assert FuncList.apply(pid, :function1, [1]) == 1
     assert FuncList.apply(pid, :function2, [1]) == 2
   end
 
   test "properly uses pattern matching" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :tuple_match, fn({:test, x}) -> x end)
+    FuncList.push(pid, :tuple_match, fn {:test, x} -> x end)
     assert FuncList.apply(pid, :tuple_match, [{:test, 1}]) == 1
 
-    FuncList.push(pid, :map_match, fn(%{test: x}) -> x end)
+    FuncList.push(pid, :map_match, fn %{test: x} -> x end)
     assert FuncList.apply(pid, :map_match, [%{test: 1}]) == 1
   end
 
   test "works with zero arguments" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn() -> 1 end)
+    FuncList.push(pid, :function_name, fn -> 1 end)
     assert FuncList.apply(pid, :function_name, []) == 1
   end
 
   test "allows out of order calls" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
-    FuncList.push(pid, :function_name, fn(1) -> 1 end)
-    FuncList.push(pid, :function_name, fn(2) -> 2 end)
-    FuncList.push(pid, :function_name, fn(3) -> 3 end)
+    FuncList.push(pid, :function_name, fn 1 -> 1 end)
+    FuncList.push(pid, :function_name, fn 2 -> 2 end)
+    FuncList.push(pid, :function_name, fn 3 -> 3 end)
     assert FuncList.apply(pid, :function_name, [2]) == 2
     assert FuncList.apply(pid, :function_name, [1]) == 1
     assert FuncList.apply(pid, :function_name, [3]) == 3
@@ -84,6 +91,7 @@ defmodule FuncListTest do
   test "raises exceptions properly" do
     {:ok, pid} = GenServer.start_link(FuncList, [])
     FuncList.push(pid, :function_name, fn -> raise "Test Error" end)
+
     assert_raise RuntimeError, "Test Error", fn ->
       FuncList.apply(pid, :function_name, [])
     end

--- a/test/support/test_behaviour.ex
+++ b/test/support/test_behaviour.ex
@@ -1,4 +1,3 @@
 defmodule TestBehaviour do
-  @callback process(String.t) :: :ok
+  @callback process(String.t()) :: :ok
 end
-

--- a/test/support/test_module.ex
+++ b/test/support/test_module.ex
@@ -3,8 +3,7 @@ defmodule TestModule do
   def sleep(x), do: x
   def process, do: nil
   def process(x), do: x
-  def process(x, y, z), do: {x,y,z}
-  def another_function,  do: nil
+  def process(x, y, z), do: {x, y, z}
+  def another_function, do: nil
   def another_function(x), do: x
 end
-


### PR DESCRIPTION
Elixir 1.6 complains about missing `init` callback in `Double.Eval` module, added default implementation.

Also ran Elixir code formatter on all .ex and .exs files.