### PR TITLE
New stub syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ It does NOT override behavior of existing modules or functions.
 Double uses Elixir's built-in language features such as pattern matching and message passing to
 give you everything you would normally need a complex mocking tool for.
 
-Checkout [Testing Elixir: The Movie](https://youtu.be/cyU_SFyVRro) for a fun introduction to Double and unit testing in Elixir.
-
 ## Installation
 The package can be installed as:
 
@@ -13,7 +11,7 @@ The package can be installed as:
 
   ```elixir
   def deps do
-    [{:double, "~> 0.6.6", only: :test}]
+    [{:double, "~> 0.7.0", only: :test}]
   end
   ```
 
@@ -26,14 +24,14 @@ Application.ensure_all_started(:double)
 ```
 
 ### Module/Behaviour Doubles
-Double creates a fake module based off of a behaviour or another module.
+Double creates a fake module based off of a behaviour or module.
 You can use this module like any other module that you call functions on.
 Each stub you define will verify that the function name and arity are defined in the target module or behaviour.
 
 ```elixir
 defmodule Example do
   def process(io \\ IO) do # allow an alternative dependency to be passed
-    io.puts("It works without mocking libraries")
+    io.puts("It works without mocking libraries!")
   end
 end
 
@@ -42,14 +40,12 @@ defmodule ExampleTest do
   import Double
 
   test "example outputs to console" do
-    stub = IO
-    |> double()
-    |> allow(:puts, fn(_msg) -> :ok end)
+    io_stub = stub(IO,:puts, fn(_msg) -> :ok end)
 
-    Example.process(stub) # inject the stub module
+    Example.process(io_stub) # inject the stub module
 
     # use built-in ExUnit assert_receive/refute_receive to verify things
-    assert_receive({:puts, "It works without mocking libraries"})
+    assert_receive({IO, :puts, "It works without mocking libraries!"})
   end
 end
 ```
@@ -58,75 +54,66 @@ end
 ### Basics
 ```elixir
 # Stub a function
-stub = ExampleModule
-|> double()
-|> allow(:add, fn(x, y) -> x + y end)
-stub.add(2, 2) # 4
+dbl = stub(ExampleModule, :add, fn(x, y) -> x + y end)
+dbl.add(2, 2) # 4
 
 # Pattern match arguments
-stub = Application
-|> double()
-|> allow(:ensure_all_started, fn(:logger) -> nil end)
-stub.ensure_all_started(:logger) # nil
-stub.ensure_all_started(:something) # raises FunctionClauseError
+dbl = stub(Application, :ensure_all_started, fn(:logger) -> nil end)
+dbl.ensure_all_started(:logger) # nil
+dbl.ensure_all_started(:something) # raises FunctionClauseError
 
 # Stub as many functions as you want
-stub = ExampleModule
-|> double()
-|> allow(:add, fn(x, y) -> x + y end)
-|> allow(:subtract, fn(x, y) -> x - y end)
+dbl = ExampleModule
+|> stub(:add, fn(x, y) -> x + y end)
+|> stub(:subtract, fn(x, y) -> x - y end)
 ```
 
 ### Different return values for different arguments
 ```elixir
-stub = ExampleModule
-|> double()
-|> allow(:example, fn("one") -> 1 end)
-|> allow(:example, fn("two") -> 2 end)
-|> allow(:example, fn("three") -> 3 end)
+dbl = ExampleModule
+|> stub(:example, fn("one") -> 1 end)
+|> stub(:example, fn("two") -> 2 end)
+|> stub(:example, fn("three") -> 3 end)
 
-stub.example("one") # 1
-stub.example("two") # 2
-stub.example("three") # 3
+dbl.example("one") # 1
+dbl.example("two") # 2
+dbl.example("three") # 3
 ```
 
 ### Multiple calls returning different values
 ```elixir
-stub = ExampleModule
-|> double()
-|> allow(:example, fn("count") -> 1 end)
-|> allow(:example, fn("count") -> 2 end)
+dbl = ExampleModule
+|> stub(:example, fn("count") -> 1 end)
+|> stub(:example, fn("count") -> 2 end)
 
-stub.example("count") # 1
-stub.example("count") # 2
-stub.example("count") # 2
+dbl.example("count") # 1
+dbl.example("count") # 2
+dbl.example("count") # 2
 ```
 
 ### Exceptions
 ```elixir
-stub = ExampleModule
-|> double()
-|> allow(:example_with_error_type, fn -> raise RuntimeError, "kaboom!" end)
-|> allow(:example_with_error_type, fn -> raise "kaboom!" end)
+dbl = ExampleModule
+|> stub(:example_with_error_type, fn -> raise RuntimeError, "kaboom!" end)
+|> stub(:example_with_error_type, fn -> raise "kaboom!" end)
 ```
 
 ### Verifying calls
 If you want to verify that a particular stubbed function was actually executed,
 Double ensures that a message is receivable to your test process so you can just use the built-in ExUnit `assert_receive/assert_received`.
-The message is a tuple starting with the function name, and then the arguments received.
+The message is a 3-tuple `{module, :function, [arg1, arg2]}`and .
 
 ```elixir
-stub = ExampleModule
-|> double()
-|> allow(:example, fn("count") -> 1 end)
-stub.example("count")
-assert_receive({:example, "count"})
+dbl = ExampleModule
+|> stub(:example, fn("count") -> 1 end)
+dbl.example("count")
+assert_receive({ExampleModule, :example, "count"})
 ```
 Remember that pattern matching is your friend so you can do all kinds of neat tricks on these messages.
 ```elixir
-assert_receive({:example, "c" <> _rest}) # verify starts with "c"
-assert_receive({:example, %{test: 1}) # pattern match map arguments
-assert_receive({:example, x}) # assign an argument to x to verify another way
+assert_receive({ExampleModule, :example, "c" <> _rest}) # verify starts with "c"
+assert_receive({ExampleModule, :example, %{test: 1}) # pattern match map arguments
+assert_receive({ExampleModule, :example, x}) # assign an argument to x to verify another way
 assert x == "count"
 ```
 
@@ -134,9 +121,7 @@ assert x == "count"
 By default your setups will check the source module to ensure the function exists with the correct arity.
 
 ```elixir
-IO
-|> double()
-|> allow(:non_existent_function, fn(x) -> x end) # raises VerifyingDoubleError
+stub(IO, :non_existent_function, fn(x) -> x end) # raises VerifyingDoubleError
 ```
 
 ### Clearing Stubs
@@ -144,14 +129,12 @@ Occasionally it's useful to clear the stubs for an existing double. This is usef
 a shared setup and a test needs to change the way a double is stubbed without recreating the whole thing.
 
 ```elixir
-stub = IO
-|> double()
-|> allow(:puts, fn(_) -> :ok end)
-|> allow(:inspect, fn(_) -> :ok end)
+dbl = IO
+|> stub(:puts, fn(_) -> :ok end)
+|> stub(:inspect, fn(_) -> :ok end)
 
 # later
-stub |> clear(:puts) # clear an individual function
-stub |> clear([:puts, :inspect]) # clear a list of functions
-stub |> clear() # clear all functions
+dbl |> clear(:puts) # clear an individual function
+dbl |> clear([:puts, :inspect]) # clear a list of functions
+dbl |> clear() # clear all functions
 ```
-

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Double.Mixfile do
   use Mix.Project
-  @version "0.6.6"
+  @version "0.7.0"
 
   def project do
     [

--- a/test/stub_test.exs
+++ b/test/stub_test.exs
@@ -1,0 +1,231 @@
+defmodule StubTest do
+  use ExUnit.Case, async: false
+  import Double
+
+  test "stubs modules" do
+    assert stub(IO) |> is_atom
+  end
+
+  test "stubs erlang modules" do
+    assert stub(:application) |> is_atom
+  end
+
+  test "stubs functions" do
+    dbl =
+      TestModule
+      |> stub()
+      |> stub(:process, fn 1, 2, 3 -> 1 end)
+
+    assert dbl.process(1, 2, 3) == 1
+    assert_receive({TestModule, :process, [1, 2, 3]})
+
+    dbl = stub(dbl, :another_function, fn -> :anything end)
+    assert dbl.another_function() == :anything
+    assert_receive({TestModule, :another_function, []})
+  end
+
+  test "stubs functions without calling stub/1 first" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1, 2, 3 -> 1 end)
+
+    assert dbl.process(1, 2, 3) == 1
+    assert_receive({TestModule, :process, [1, 2, 3]})
+
+    dbl = stub(dbl, :another_function, fn -> :anything end)
+    assert dbl.another_function() == :anything
+    assert_receive({TestModule, :another_function, []})
+  end
+
+  test "allows multiple calls" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1, 2, 3 -> 1 end)
+
+    assert dbl.process(1, 2, 3) == 1
+    assert dbl.process(1, 2, 3) == 1
+  end
+
+  test "allows subsequent calls to return new values" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1, 2, 3 -> 1 end)
+      |> stub(:process, fn 1, 2, 3 -> 2 end)
+      |> stub(:process, fn 1, 2, 3 -> 3 end)
+
+    assert dbl.process(1, 2, 3) == 1
+    assert dbl.process(1, 2, 3) == 2
+    assert dbl.process(1, 2, 3) == 3
+    assert dbl.process(1, 2, 3) == 3
+  end
+
+  test "with out of order calls" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1 -> 1 end)
+      |> stub(:process, fn 2 -> 2 end)
+      |> stub(:process, fn 3 -> 3 end)
+
+    assert dbl.process(2) == 2
+    assert dbl.process(1) == 1
+    assert dbl.process(3) == 3
+    assert dbl.process(3) == 3
+  end
+
+  test "does not overwrite existing setup with same args" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1 -> 1 end)
+      |> stub(:process, fn 1 -> 2 end)
+
+    assert dbl.process(1) == 1
+    assert dbl.process(1) == 2
+  end
+
+  test "works with pinned argument variables" do
+    arg1 = "test"
+
+    dbl =
+      TestModule
+      |> stub(:process, fn ^arg1 -> arg1 end)
+
+    assert dbl.process("test") == "test"
+  end
+
+  test "stubbed exceptions" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> raise RuntimeError, "boom" end)
+
+    assert_raise RuntimeError, "boom", fn ->
+      dbl.process()
+    end
+  end
+
+  test "sets up exceptions with only a message" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> raise "boom" end)
+
+    assert_raise RuntimeError, "boom", fn ->
+      dbl.process()
+    end
+  end
+
+  test "multiple doubles" do
+    dbl1 = TestModule |> stub(:process, fn -> 1 end)
+    dbl2 = TestModule |> stub(:process, fn -> 2 end)
+
+    assert dbl1.process() == 1
+    assert dbl2.process() == 2
+  end
+
+  test "calling other modules within stub" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> :rand.uniform() end)
+
+    refute dbl.process() == dbl.process()
+  end
+
+  test "clearing previous stubs" do
+    dbl =
+      TestModule
+      |> stub(:process, fn 1 -> 1 end)
+      |> clear()
+      |> allow(:process, fn 2 -> 2 end)
+
+    assert dbl.process(2) == 2
+    refute_receive({TestModule, :process, [1]})
+    assert_receive({TestModule, :process, [2]})
+  end
+
+  test "clears individual function stubs" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> 1 end)
+      |> stub(:sleep, fn 1 -> :ok end)
+      |> clear(:process)
+      |> stub(:process, fn -> 2 end)
+
+    assert dbl.process() == 2
+    assert dbl.sleep(1) == :ok
+  end
+
+  test "clears list of function stubs" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> 1 end)
+      |> stub(:sleep, fn 1 -> :ok end)
+      |> stub(:io_puts, fn 1 -> :ok end)
+      |> clear([:process, :sleep])
+      |> stub(:process, fn -> 2 end)
+      |> stub(:sleep, fn 1 -> 2 end)
+
+    assert dbl.process() == 2
+    assert dbl.sleep(1) == 2
+    assert dbl.io_puts(1) == :ok
+  end
+
+  test "module names include source name" do
+    dbl = stub(TestModule)
+    assert "TestModuleDouble" <> _ = Atom.to_string(dbl)
+  end
+
+  test "functions are verified against target module" do
+    assert_raise VerifyingDoubleError,
+                 ~r/The function 'non_existent_function\/1' is not defined in :TestModuleDouble/,
+                 fn ->
+                   stub(TestModule, :non_existent_function, fn _ -> 1 end)
+                 end
+  end
+
+  test "works with erlang modules" do
+    dbl =
+      stub(:application)
+      |> stub(:loaded_applications, fn -> :ok end)
+
+    assert dbl.loaded_applications() == :ok
+  end
+
+  test "verifies valid behavior doubles" do
+    dbl = stub(TestBehaviour, :process, fn nil -> :ok end)
+
+    assert :ok = dbl.process(nil)
+  end
+
+  test "verifies invalid behaviour doubles" do
+    assert_raise VerifyingDoubleError,
+                 ~r/The function 'non_existent_function\/1' is not defined in :TestBehaviourDouble/,
+                 fn ->
+                   stub(TestBehaviour, :non_existent_function, fn _ -> :ok end)
+                 end
+  end
+
+  test "works with modules having macros" do
+    # Logger.info/1 is a macro
+    dbl =
+      Logger
+      |> stub(:info, fn _msg -> :ok end)
+
+    assert :ok = dbl.info(nil)
+
+    dbl =
+      Mix.Task
+      |> stub(:run, fn _, _ -> :ok end)
+
+    assert :ok = dbl.run(nil, nil)
+  end
+
+  test "works normally when called within another process" do
+    dbl =
+      TestModule
+      |> stub(:process, fn -> :ok end)
+
+    spawn(fn ->
+      dbl.process()
+    end)
+
+    assert_receive {TestModule, :process, []}
+  end
+end


### PR DESCRIPTION
TLDR:
```
dbl = stub(IO, :puts, fn(_) -> :ok end)
dbl.puts("hello double")
assert_receive({IO, :puts, ["hello double"]})
```

Resolves #29 