### PR TITLE
Prevent default Kernel imports from conflicting with allowed functions

### DIFF
--- a/test/double_test.exs
+++ b/test/double_test.exs
@@ -161,6 +161,14 @@ defmodule DoubleTest do
       assert dbl.loaded_applications() == :ok
     end
 
+    test "can override kernel functions" do
+      dbl =
+        double(TestModule)
+        |> allow(:send, fn _, _ -> :ok end)
+
+      assert dbl.send(:a, :b) == :ok
+    end
+
     test "verifies valid behavior doubles" do
       dbl =
         TestBehaviour

--- a/test/support/test_module.ex
+++ b/test/support/test_module.ex
@@ -6,4 +6,5 @@ defmodule TestModule do
   def process(x, y, z), do: {x, y, z}
   def another_function, do: nil
   def another_function(x), do: x
+  def send(a, b), do: {a, b}
 end


### PR DESCRIPTION
By default `Kernel` will import all of its functions into the generated module, which means that if you are trying to double a conflicting function head it will raise an error. Instead this attempts to detect this scenario and will not import the Kernel function if you attempt to duplicate it.