### PR TITLE
Implement Double.spy/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ ExUnit.start
 Application.ensure_all_started(:double)
 ```
 
+- [Intro](#modulebehaviour-doubles)
+- Stubs
+    - [Basics](#basics)
+    - [Advanced Return Values](#different-return-values-for-different-arguments)
+    - [Exceptions](#exceptions)
+    - [Verifying Calls](#verifying-calls)
+- [Spies](#spies)
+
 ### Module/Behaviour Doubles
 Double creates a fake module based off of a behaviour or module.
 You can use this module like any other module that you call functions on.
@@ -138,3 +146,33 @@ dbl |> clear(:puts) # clear an individual function
 dbl |> clear([:puts, :inspect]) # clear a list of functions
 dbl |> clear() # clear all functions
 ```
+
+### Spies
+Everything that works on stubs should pretty much work on spies, but the spy just automatically defaults to using the implementation of the module you're spying.
+
+Say you have already written a stub of some kind for the `IO` module:
+```
+defmodule IOStub do
+  def write(filename, content) do
+    "really bad example of writing a file"
+  end
+end
+```
+Now in your tests you can utilize this stub and "attach" spying behavior like so:
+```
+test "spying on modules works" do
+  # use spy/1 instead of stub
+  spy = spy(IOStub)
+
+  # The spy works just like the stub you defined.
+  assert spy.write("anything", "anything") == "really bad example of writing a file"
+
+  # But it also gives you this!
+  assert_receive {IOStub, :write, ["anything", "anything"]}
+
+  # The spy can also be stubbed if you want to override a specific function while leaving others
+  stub(spy, :write, fn(_, _) -> :stubbed end)
+  assert spy.write("anything", "anything") == :ok
+end
+```
+

--- a/lib/double.ex
+++ b/lib/double.ex
@@ -21,18 +21,22 @@ defmodule Double do
 
   def spy(target) do
     target.module_info(:functions)
-    |> Enum.reject(fn({k, _}) ->
-      [:__info__, :module_info] |> Enum.member?(k)
-        || String.starts_with?("#{k}", "_")
-        || String.starts_with?("#{k}", "-")
+    |> Enum.reject(fn {k, _} ->
+      [:__info__, :module_info] |> Enum.member?(k) ||
+        String.starts_with?("#{k}", "_") ||
+        String.starts_with?("#{k}", "-")
     end)
-    |> Enum.reduce(stub(target), fn({func, arity}, dbl) ->
+    |> Enum.reduce(stub(target), fn {func, arity}, dbl ->
       args = SpyHelper.create_args(target, arity)
-      {f, _} = quote do
-        fn(unquote_splicing(args)) ->
-          apply(unquote(target), unquote(func), [unquote_splicing(args)])
+
+      {f, _} =
+        quote do
+          fn unquote_splicing(args) ->
+            apply(unquote(target), unquote(func), [unquote_splicing(args)])
+          end
         end
-    end |> Code.eval_quoted()
+        |> Code.eval_quoted()
+
       stub(dbl, func, f)
     end)
   end

--- a/lib/double.ex
+++ b/lib/double.ex
@@ -6,8 +6,7 @@ defmodule Double do
   give you everything you would normally need a complex mocking tool for.
   """
 
-  alias Double.Registry
-  alias Double.FuncList
+  alias Double.{FuncList, Registry, SpyHelper}
   use GenServer
 
   @default_options [verify: true, send_stubbed_module: false]
@@ -20,7 +19,23 @@ defmodule Double do
              | {atom, String.t()}}
   @type double_option :: {:verify, true | false}
 
-  # API
+  def spy(target) do
+    target.module_info(:functions)
+    |> Enum.reject(fn({k, _}) ->
+      [:__info__, :module_info] |> Enum.member?(k)
+        || String.starts_with?("#{k}", "_")
+        || String.starts_with?("#{k}", "-")
+    end)
+    |> Enum.reduce(stub(target), fn({func, arity}, dbl) ->
+      args = SpyHelper.create_args(target, arity)
+      {f, _} = quote do
+        fn(unquote_splicing(args)) ->
+          apply(unquote(target), unquote(func), [unquote_splicing(args)])
+        end
+    end |> Code.eval_quoted()
+      stub(dbl, func, f)
+    end)
+  end
 
   @spec stub(atom, atom, function) :: atom
   def stub(dbl), do: double(dbl, Keyword.put(@default_options, :send_stubbed_module, true))

--- a/lib/double/spy_helper.ex
+++ b/lib/double/spy_helper.ex
@@ -4,7 +4,8 @@ defmodule Double.SpyHelper do
   """
 
   def create_args(_, 0), do: []
+
   def create_args(fn_mod, arg_cnt) do
-    Enum.map(1..arg_cnt, &(Macro.var (:"arg#{&1}"), fn_mod))
+    Enum.map(1..arg_cnt, &Macro.var(:"arg#{&1}", fn_mod))
   end
 end

--- a/lib/double/spy_helper.ex
+++ b/lib/double/spy_helper.ex
@@ -1,0 +1,10 @@
+defmodule Double.SpyHelper do
+  @moduledoc """
+  Helper functions for spy args
+  """
+
+  def create_args(_, 0), do: []
+  def create_args(fn_mod, arg_cnt) do
+    Enum.map(1..arg_cnt, &(Macro.var (:"arg#{&1}"), fn_mod))
+  end
+end

--- a/test/spy_test.exs
+++ b/test/spy_test.exs
@@ -1,0 +1,65 @@
+defmodule SpyTest do
+  use ExUnit.Case, async: false
+  import Double
+
+  test "spies modules" do
+    assert spy(IO) |> is_atom
+  end
+
+  test "spies erlang modules" do
+    assert spy(:application) |> is_atom
+  end
+
+  test "spies function calls" do
+    spy =
+      TestModule
+      |> spy()
+      #|> stub(:process, fn 1, 2, 3 -> 1 end)
+
+    assert spy.process(1, 2, 3) == {1, 2, 3}
+    assert_receive({TestModule, :process, [1, 2, 3]})
+
+    assert spy.another_function(42) == 42
+    assert_receive({TestModule, :another_function, [42]})
+  end
+
+  test "allows multiple calls" do
+    spy = TestModule |> spy()
+
+    assert spy.process(1, 2, 3) == {1, 2, 3}
+    assert spy.process(3, 2, 1) == {3, 2, 1}
+    assert_receive({TestModule, :process, [1,2,3]})
+    assert_receive({TestModule, :process, [3,2,1]})
+  end
+
+  test "allows subsequent stubbing of functions" do
+    dbl =
+      TestModule
+      |> spy()
+      |> stub(:process, fn 1, 2, 3 -> 2 end)
+
+    assert dbl.process(1, 2, 3) == {1, 2, 3}
+    assert dbl.process(1, 2, 3) == 2
+  end
+
+  test "clearing spy to stub a function" do
+    dbl =
+      TestModule
+      |> spy()
+      |> clear()
+      |> allow(:process, fn 2 -> 2 end)
+
+    assert dbl.process(2) == 2
+    assert_receive({TestModule, :process, [2]})
+  end
+
+  test "clears individual function stubs" do
+    dbl =
+      TestModule
+      |> spy()
+      |> clear(:process)
+      |> stub(:process, fn -> 2 end)
+
+    assert dbl.process() == 2
+  end
+end

--- a/test/spy_test.exs
+++ b/test/spy_test.exs
@@ -14,7 +14,8 @@ defmodule SpyTest do
     spy =
       TestModule
       |> spy()
-      #|> stub(:process, fn 1, 2, 3 -> 1 end)
+
+    # |> stub(:process, fn 1, 2, 3 -> 1 end)
 
     assert spy.process(1, 2, 3) == {1, 2, 3}
     assert_receive({TestModule, :process, [1, 2, 3]})
@@ -28,8 +29,8 @@ defmodule SpyTest do
 
     assert spy.process(1, 2, 3) == {1, 2, 3}
     assert spy.process(3, 2, 1) == {3, 2, 1}
-    assert_receive({TestModule, :process, [1,2,3]})
-    assert_receive({TestModule, :process, [3,2,1]})
+    assert_receive({TestModule, :process, [1, 2, 3]})
+    assert_receive({TestModule, :process, [3, 2, 1]})
   end
 
   test "allows subsequent stubbing of functions" do


### PR DESCRIPTION
Everything that works on stubs should pretty much work on spies, but the spy just automatically defaults to using the implementation of the module you're spying. 

Implement spies for when you either:
1. Already have a stub implemented, but want the spy `assert_receive` feature for verifying in your tests that your stub was called.  
2. Don't want to stub out the implementation, but still want to `assert_receive` that your implementation is being called as expected.

### Example
Say you have already written a stub of some kind for the `IO` module.
```
defmodule IOStub do
  def write(filename, content) do
    "really bad example of writing a file"
  end
end
```
Now in your tests you can utilize this stub and "attach" spying behavior like so:
```
test "spying on modules works" do
  # use spy/1 instead of stub
  spy = spy(IOStub)

  # The spy works just like the stub you defined.
  assert spy.write("anything", "anything") == "really bad example of writing a file"

  # But it also gives you this!
  assert_receive {IOStub, :write, ["anything", "anything"]} 

  # The spy can also be stubbed if you want to override a specific function while leaving others
  stub(spy, :write, fn(_, _) -> :stubbed end)
  assert spy.write("anything", "anything") == :ok
end
```
